### PR TITLE
Call GC manually

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,7 +1,7 @@
 FROM golang:1.16-buster
 
 RUN apt-get update -y && \
-    apt-get install -y jq
+    apt-get install -y jq time
 
 # Install staticcheck
 RUN curl --silent "https://api.github.com/repos/dominikh/go-tools/releases/latest" | \

--- a/src/csv/slicedWriter/slice.go
+++ b/src/csv/slicedWriter/slice.go
@@ -8,6 +8,7 @@ import (
 	"keboola.processor-split-table/src/kbc"
 	"keboola.processor-split-table/src/utils"
 	"os"
+	"runtime"
 )
 
 const OutBufferSize = 20 * 1024 * 1024 // 20MB
@@ -85,6 +86,9 @@ func (s *slice) Close() {
 	if err != nil {
 		kbc.PanicApplicationError("Cannot close file when closing slice \"%s\": %s", s.path, err)
 	}
+
+	// Go runtime doesn't know maximum memory in Kubernetes/Docker, so we clean-up after each slice.
+	runtime.GC()
 }
 
 func (s *slice) IsSpaceForNextRow(rowLength uint64) bool {


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-847

Testoval som processor na CSAS stacku, so `numberOfSlices = 60`.
Spadlo to na nedostatok pamate:
![image](https://user-images.githubusercontent.com/19371734/119154451-781a3480-ba52-11eb-82c0-32a927e8675e.png)


Debugoval som to lokalne, a zistil som, ... ze Go runtime v Kubernetes/Docker nevie kolko ma maximalne pamate k dispozicii. Cita to cez `ulimit`, ktory sa bezne nenastavuje aj ked je pamat obmedzena. 

Preto som pridal manualne cistenie pamate po kazdej `slice`, co o par `ms` spomali beh programu, ale to nevadi.

![image](https://user-images.githubusercontent.com/19371734/119154593-9849f380-ba52-11eb-89aa-1ee3c81aaa1d.png)

![image](https://user-images.githubusercontent.com/19371734/119154613-9da73e00-ba52-11eb-837a-4c26294245ab.png)
