### PR TITLE
Fix error reporting

### DIFF
--- a/internal/pkg/csv/columnsparser/parse.go
+++ b/internal/pkg/csv/columnsparser/parse.go
@@ -2,7 +2,8 @@ package columnsparser
 
 import (
 	"bytes"
-	"fmt"
+
+	"github.com/keboola/processor-split-table/internal/pkg/kbc"
 )
 
 type Parser struct {
@@ -43,7 +44,7 @@ func (p *Parser) Parse(row []byte) ([]string, error) {
 
 	// Check if enclosure is ended
 	if p.insideEnclosure {
-		return nil, fmt.Errorf("reached end of the row, but enclosure is not ended")
+		return nil, kbc.UserErrorf("reached end of the row, but enclosure is not ended")
 	}
 
 	return p.columns, nil
@@ -65,7 +66,7 @@ func (p *Parser) processChar(char byte) error {
 		}
 
 		if !p.insideEnclosure && len(p.current) > 0 {
-			return fmt.Errorf("unexpected token \"%s\" before enclosure at position %d", p.current, p.index+1)
+			return kbc.UserErrorf("unexpected token \"%s\" before enclosure at position %d", p.current, p.index+1)
 		}
 
 		// Invert state

--- a/internal/pkg/csv/columnsparser/parse_test.go
+++ b/internal/pkg/csv/columnsparser/parse_test.go
@@ -1,7 +1,6 @@
 package columnsparser
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +10,7 @@ type testData struct {
 	comment         string
 	input           []byte
 	expectedColumns []string
-	expectedErr     error
+	expectedErr     string
 }
 
 func TestParse(t *testing.T) {
@@ -21,7 +20,9 @@ func TestParse(t *testing.T) {
 		parser := NewParser(',', '"')
 		columns, err := parser.Parse(data.input)
 		assert.Equal(t, data.expectedColumns, columns, data.comment)
-		assert.Equal(t, data.expectedErr, err, data.comment)
+		if data.expectedErr != "" && assert.Error(t, err) {
+			assert.Equal(t, data.expectedErr, err.Error(), data.comment)
+		}
 	}
 }
 
@@ -31,91 +32,81 @@ func GetTestParseHeaderData() []testData {
 			comment:         "Empty row",
 			input:           []byte(""),
 			expectedColumns: nil,
-			expectedErr:     nil,
 		},
 		{
 			comment:         "Columns",
 			input:           []byte("\"a\",\"a\"\"\nb\",\"abc\""),
 			expectedColumns: []string{"a", "a\"\nb", "abc"},
-			expectedErr:     nil,
 		},
 		{
 			comment:         "Columns - tolerate missing enclosure",
 			input:           []byte("a,ab,abc"),
 			expectedColumns: []string{"a", "ab", "abc"},
-			expectedErr:     nil,
 		},
 		{
 			comment:         "Column",
 			input:           []byte("\"abc\""),
 			expectedColumns: []string{"abc"},
-			expectedErr:     nil,
 		},
 		{
 			comment:         "Column, delimiter",
 			input:           []byte("\"abc\","),
 			expectedColumns: []string{"abc", ""},
-			expectedErr:     nil,
 		},
 		{
 			comment:         "Column, new line",
 			input:           []byte("\"abc\"\n"),
 			expectedColumns: []string{"abc"},
-			expectedErr:     nil,
 		},
 		{
 			comment:         "Column[with escaped enclosure + new line]",
 			input:           []byte("\"a\"\"b\nc\""),
 			expectedColumns: []string{"a\"b\nc"},
-			expectedErr:     nil,
 		},
 		{
 			comment:         "Column[with escaped enclosure + new line], delimiter",
 			input:           []byte("\"a\"\"b\nc\","),
 			expectedColumns: []string{"a\"b\nc", ""},
-			expectedErr:     nil,
 		},
 		{
 			comment:         "Column[with escaped enclosure + new line], new line",
 			input:           []byte("\"a\"\"b\nc\"\n"),
 			expectedColumns: []string{"a\"b\nc"},
-			expectedErr:     nil,
 		},
 		{
 			comment:         "Delimiter",
 			input:           []byte(","),
 			expectedColumns: []string{"", ""},
-			expectedErr:     nil,
 		},
 		{
 			comment:         "Unfinished enclosure - 1",
 			input:           []byte("\""),
 			expectedColumns: nil,
-			expectedErr:     fmt.Errorf("reached end of the row, but enclosure is not ended"),
+			expectedErr:     "reached end of the row, but enclosure is not ended",
 		},
 		{
 			comment:         "Unfinished enclosure - 2",
 			input:           []byte("\"aaa"),
 			expectedColumns: nil,
-			expectedErr:     fmt.Errorf("reached end of the row, but enclosure is not ended"),
+			expectedErr:     "reached end of the row, but enclosure is not ended",
 		},
 		{
 			comment:         "Unfinished enclosure - 3",
 			input:           []byte("\"aaa\",\"bbb"),
 			expectedColumns: nil,
-			expectedErr:     fmt.Errorf("reached end of the row, but enclosure is not ended"),
+			expectedErr:     "reached end of the row, but enclosure is not ended",
 		},
 		{
 			comment:         "Input before enclosure - 1",
 			input:           []byte("aaa\""),
 			expectedColumns: nil,
-			expectedErr:     fmt.Errorf("unexpected token \"aaa\" before enclosure at position 4"),
+			expectedErr:     "unexpected token \"aaa\" before enclosure at position 4",
 		},
 		{
 			comment:         "Input before enclosure - 2",
 			input:           []byte("\"aaa\",bbb\""),
 			expectedColumns: nil,
-			expectedErr:     fmt.Errorf("unexpected token \"bbb\" before enclosure at position 10"),
+			expectedErr:     "unexpected token \"bbb\" before enclosure at position 10",
 		},
 	}
 }

--- a/internal/pkg/csv/slicedwriter/writer_test.go
+++ b/internal/pkg/csv/slicedwriter/writer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/keboola/processor-split-table/internal/pkg/config"
 	"github.com/keboola/processor-split-table/internal/pkg/utils"
@@ -33,7 +34,8 @@ func TestNewSlicedWriter(t *testing.T) {
 	}
 
 	// Create writer
-	w := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	w, err := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	require.NoError(t, err)
 
 	// Assert
 	assert.Equal(t, tempDir, w.dirPath)
@@ -62,8 +64,10 @@ func TestCreateNextSlice(t *testing.T) {
 	}
 
 	// Create writer
-	w := NewSlicedWriterFromConf(conf, 1000, tempDir)
-	w.createNextSlice()
+	w, err := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	require.NoError(t, err)
+
+	require.NoError(t, w.createNextSlice())
 
 	// Assert
 	assert.Equal(t, tempDir, w.dirPath)
@@ -92,7 +96,8 @@ func TestIsSpaceForNextRowBytes(t *testing.T) {
 	}
 
 	// Create writer
-	w := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	w, err := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	require.NoError(t, err)
 	w.allRows = 10
 	w.allBytes = 200
 	w.slice.rows = 5
@@ -120,7 +125,8 @@ func TestIsSpaceForNextRowRows(t *testing.T) {
 	}
 
 	// Create writer
-	w := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	w, err := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	require.NoError(t, err)
 	w.allRows = 10
 	w.allBytes = 200
 	w.slice.rows = 5 // <<<<<< 5 rows left
@@ -151,24 +157,25 @@ func TestBytesMode(t *testing.T) {
 	}
 
 	// Create writer
-	w := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	w, err := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	require.NoError(t, err)
 
 	// 1 slice
-	w.Write([]byte("\"1bc\",\"def\"\n")) // <<<<<< 12B
+	assert.NoError(t, w.Write([]byte("\"1bc\",\"def\"\n"))) // <<<<<< 12B
 	assert.Equal(t, uint32(1), w.sliceNumber)
-	w.Write([]byte("\"2bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"2bc\",\"def\"\n")))
 	assert.Equal(t, uint32(1), w.sliceNumber) // <<<<<< 24B
-	w.Write([]byte("\"3bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"3bc\",\"def\"\n")))
 	assert.Equal(t, uint32(1), w.sliceNumber) // <<<<<< 32B
 	// 2 slice
-	w.Write([]byte("\"4bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"4bc\",\"def\"\n")))
 	assert.Equal(t, uint32(2), w.sliceNumber) // <<<<<< 44B -> new slice -> 12B
-	w.Write([]byte("\"5bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"5bc\",\"def\"\n")))
 	assert.Equal(t, uint32(2), w.sliceNumber)
-	w.Write([]byte("\"6bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"6bc\",\"def\"\n")))
 	assert.Equal(t, uint32(2), w.sliceNumber)
 	// 3 slice
-	w.Write([]byte("\"7bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"7bc\",\"def\"\n")))
 	assert.Equal(t, uint32(3), w.sliceNumber)
 }
 
@@ -189,24 +196,25 @@ func TestRowsMode(t *testing.T) {
 	}
 
 	// Create writer
-	w := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	w, err := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	require.NoError(t, err)
 
 	// 1 slice
-	w.Write([]byte("\"1bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"1bc\",\"def\"\n")))
 	assert.Equal(t, uint32(1), w.sliceNumber)
-	w.Write([]byte("\"2bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"2bc\",\"def\"\n")))
 	assert.Equal(t, uint32(1), w.sliceNumber)
-	w.Write([]byte("\"3bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"3bc\",\"def\"\n")))
 	assert.Equal(t, uint32(1), w.sliceNumber)
 	// 2 slice
-	w.Write([]byte("\"4bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"4bc\",\"def\"\n")))
 	assert.Equal(t, uint32(2), w.sliceNumber)
-	w.Write([]byte("\"5bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"5bc\",\"def\"\n")))
 	assert.Equal(t, uint32(2), w.sliceNumber)
-	w.Write([]byte("\"6bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"6bc\",\"def\"\n")))
 	assert.Equal(t, uint32(2), w.sliceNumber)
 	// 3 slice
-	w.Write([]byte("\"7bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"7bc\",\"def\"\n")))
 	assert.Equal(t, uint32(3), w.sliceNumber)
 }
 
@@ -228,26 +236,27 @@ func TestSlicesMode(t *testing.T) {
 	}
 
 	// Create writer
-	w := NewSlicedWriterFromConf(conf, 7*12, tempDir)
+	w, err := NewSlicedWriterFromConf(conf, 7*12, tempDir)
+	require.NoError(t, err)
 	assert.Equal(t, uint32(3), w.maxSlices)
 	assert.Equal(t, uint64(28), w.bytesPerSlice) // 7 row * 12 bytes / 3 slices = 28 bytes per slice
 
 	// 1 slice
-	w.Write([]byte("\"1bc\",\"def\"\n")) // 12 bytes
+	assert.NoError(t, w.Write([]byte("\"1bc\",\"def\"\n"))) // 12 bytes
 	assert.Equal(t, uint32(1), w.sliceNumber)
-	w.Write([]byte("\"2bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"2bc\",\"def\"\n")))
 	assert.Equal(t, uint32(1), w.sliceNumber)
 	// 2 slice
-	w.Write([]byte("\"3bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"3bc\",\"def\"\n")))
 	assert.Equal(t, uint32(2), w.sliceNumber)
-	w.Write([]byte("\"4bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"4bc\",\"def\"\n")))
 	assert.Equal(t, uint32(2), w.sliceNumber)
 	// 3 slice
-	w.Write([]byte("\"5bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"5bc\",\"def\"\n")))
 	assert.Equal(t, uint32(3), w.sliceNumber)
-	w.Write([]byte("\"6bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"6bc\",\"def\"\n")))
 	assert.Equal(t, uint32(3), w.sliceNumber)
-	w.Write([]byte("\"7bc\",\"def\"\n"))
+	assert.NoError(t, w.Write([]byte("\"7bc\",\"def\"\n")))
 	assert.Equal(t, uint32(3), w.sliceNumber)
 }
 
@@ -259,11 +268,12 @@ func TestWriteCsv(t *testing.T) {
 
 	for _, testData := range getReadCsvTestData() {
 		tempDir := t.TempDir()
-		w := NewSlicedWriterFromConf(testData.conf, 1000, tempDir)
+		w, err := NewSlicedWriterFromConf(testData.conf, 1000, tempDir)
+		require.NoError(t, err)
 		for _, row := range testData.rows {
-			w.Write([]byte(row))
+			assert.NoError(t, w.Write([]byte(row)))
 		}
-		w.Close()
+		assert.NoError(t, w.Close())
 
 		// Assert
 		utils.AssertDirectoryContentsSame(t, rootDir+"/fixtures/"+testData.expectedPath, tempDir)

--- a/internal/pkg/finder/finder.go
+++ b/internal/pkg/finder/finder.go
@@ -1,12 +1,11 @@
 package finder
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/keboola/processor-split-table/internal/pkg/kbc"
 )
 
 type FileType int
@@ -26,7 +25,7 @@ type FileNode struct {
 
 // FindFilesRecursive returns all files/dirs in the rootDir and sub-dirs.
 // Each entry is mapped to FileNode. FileNode.FileType determines further work.
-func FindFilesRecursive(rootDir string) []*FileNode {
+func FindFilesRecursive(rootDir string) ([]*FileNode, error) {
 	// Found nodes
 	var files []*FileNode
 
@@ -90,10 +89,10 @@ func FindFilesRecursive(rootDir string) []*FileNode {
 		return nil
 	})
 	if err != nil {
-		kbc.PanicApplicationErrorf("Cannot iterate over directory \"%s\": %s \n", rootDir, err)
+		return nil, fmt.Errorf("cannot iterate over directory \"%s\": %w", rootDir, err)
 	}
 
-	return files
+	return files, nil
 }
 
 func isSlicedCsvTable(entry os.DirEntry, relativePath string) bool {

--- a/internal/pkg/finder/finder_test.go
+++ b/internal/pkg/finder/finder_test.go
@@ -6,13 +6,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFindFilesRecursiveEmpty(t *testing.T) {
 	t.Parallel()
 
 	_, testFile, _, _ := runtime.Caller(0)
-	files := FindFilesRecursive(filepath.Dir(testFile) + "/fixtures/empty")
+
+	files, err := FindFilesRecursive(filepath.Dir(testFile) + "/fixtures/empty")
+	require.NoError(t, err)
+
 	var expected []*FileNode
 	assert.Equal(t, expected, files)
 }
@@ -21,7 +25,10 @@ func TestFindFilesRecursiveComplex(t *testing.T) {
 	t.Parallel()
 
 	_, testFile, _, _ := runtime.Caller(0)
-	files := FindFilesRecursive(filepath.Dir(testFile) + "/fixtures/complex")
+
+	files, err := FindFilesRecursive(filepath.Dir(testFile) + "/fixtures/complex")
+	require.NoError(t, err)
+
 	expected := []*FileNode{
 		{
 			FileType:     Directory,

--- a/internal/pkg/kbc/kbc.go
+++ b/internal/pkg/kbc/kbc.go
@@ -8,44 +8,28 @@ import (
 	"strings"
 )
 
-type Error struct {
-	message  string
-	exitCode int
+const NewFilePermissions = 0o600
+
+type Error interface {
+	error
+	ExitCode() int
 }
 
-func (e *Error) Error() string {
-	return e.message
+// UserError is an expected error that should be displayed to the user.
+// It triggers exit code 1.
+type UserError struct {
+	error
 }
 
 // ExitCode is processed in main.go.
-func (e *Error) ExitCode() int {
-	return e.exitCode
+func (e UserError) ExitCode() int {
+	return 1
 }
 
-// UserError logs message and stops program execution with exit code 1.
-func UserError(format string, a ...interface{}) *Error {
+// UserErrorf logs message and stops program execution with exit code 1.
+func UserErrorf(format string, a ...interface{}) error {
 	format = strings.TrimSpace(format)
-	return &Error{
-		fmt.Sprintf(format, a...),
-		1,
-	}
-}
-
-// ApplicationError logs message and stops program execution with exit code 2.
-func ApplicationError(format string, a ...interface{}) *Error {
-	format = strings.TrimSpace(format)
-	return &Error{
-		fmt.Sprintf(format, a...),
-		2,
-	}
-}
-
-func PanicApplicationErrorf(format string, a ...interface{}) {
-	panic(ApplicationError(format, a...))
-}
-
-func PanicUserErrorf(format string, a ...interface{}) {
-	panic(UserError(format, a...))
+	return &UserError{error: fmt.Errorf(format, a...)}
 }
 
 func GetDataDir() string {

--- a/test/processor/complex/expected-stdout
+++ b/test/processor/complex/expected-stdout
@@ -8,10 +8,10 @@ Copying "files/sub/dir/foo6.csv".
 Copying "tables/sub/dir/foo7.bar".
 Copying "tables/sub/dir/foo8.csv".
 Slicing table "tables/table1.csv".
-Table "tables/table1.csv" sliced. Written 1 parts, 1 rows, total size 8 B. Manifest created.
+Table "tables/table1.csv" sliced, written 1 slices, 1 rows, total size 8 B, manifest created.
 Slicing table "tables/table2.csv".
-Table "tables/table2.csv" sliced. Written 1 parts, 1 rows, total size 8 B. Columns added to manifest.
+Table "tables/table2.csv" sliced, written 1 slices, 1 rows, total size 8 B, columns added to manifest.
 Copying already sliced table "tables/table3.csv".
 Copying already sliced table "tables/table4.csv".
 Slicing table "tables/table5.csv".
-Table "tables/table5.csv" sliced. Written 1 parts, 3 rows, total size 24 B.
+Table "tables/table5.csv" sliced, written 1 slices, 3 rows, total size 24 B.

--- a/test/processor/custom-delimiter/expected-stdout
+++ b/test/processor/custom-delimiter/expected-stdout
@@ -1,3 +1,3 @@
 Configured max 123 rows per slice.
 Slicing table "tables/table.csv".
-Table "tables/table.csv" sliced. Written 1 parts, 3 rows, total size 30 B. Columns added to manifest.
+Table "tables/table.csv" sliced, written 1 slices, 3 rows, total size 30 B, columns added to manifest.

--- a/test/processor/custom-enclosure/expected-stdout
+++ b/test/processor/custom-enclosure/expected-stdout
@@ -1,3 +1,3 @@
 Configured max 123 rows per slice.
 Slicing table "tables/table.csv".
-Table "tables/table.csv" sliced. Written 1 parts, 3 rows, total size 30 B. Columns added to manifest.
+Table "tables/table.csv" sliced, written 1 slices, 3 rows, total size 30 B, columns added to manifest.

--- a/test/processor/escaping/expected-stdout
+++ b/test/processor/escaping/expected-stdout
@@ -1,3 +1,3 @@
 Configured max 500 MiB per slice.
 Slicing table "tables/escaping.csv".
-Table "tables/escaping.csv" sliced. Written 1 parts, 7 rows, total size 410 B. Manifest created.
+Table "tables/escaping.csv" sliced, written 1 slices, 7 rows, total size 410 B, manifest created.

--- a/test/processor/gzip/expected-stdout
+++ b/test/processor/gzip/expected-stdout
@@ -1,4 +1,4 @@
 Configured max 20 B per slice.
 Gzip enabled, compression level = 2.
 Slicing table "tables/tenRows.csv".
-Table "tables/tenRows.csv" sliced. Written 6 parts, 10 rows, total size 101 B. Gzipped size * B. Manifest created.
+Table "tables/tenRows.csv" sliced, written 6 slices, 10 rows, total size 101 B, gzipped size * B, manifest created.

--- a/test/processor/missing-config/expected-stderr
+++ b/test/processor/missing-config/expected-stderr
@@ -1,1 +1,1 @@
-Config file not found.
+Error: config file not found

--- a/test/processor/missing-header/expected-stderr
+++ b/test/processor/missing-header/expected-stderr
@@ -1,1 +1,1 @@
-Missing header row in CSV "empty.csv".
+Error: missing header row in CSV "empty.csv"

--- a/test/processor/mode-bytes/expected-stdout
+++ b/test/processor/mode-bytes/expected-stdout
@@ -1,3 +1,3 @@
 Configured max 20 B per slice.
 Slicing table "tables/tenRows.csv".
-Table "tables/tenRows.csv" sliced. Written 6 parts, 10 rows, total size 101 B. Manifest created.
+Table "tables/tenRows.csv" sliced, written 6 slices, 10 rows, total size 101 B, manifest created.

--- a/test/processor/mode-rows/expected-stdout
+++ b/test/processor/mode-rows/expected-stdout
@@ -1,3 +1,3 @@
 Configured max 3 rows per slice.
 Slicing table "tables/tenRows.csv".
-Table "tables/tenRows.csv" sliced. Written 4 parts, 10 rows, total size 101 B. Manifest created.
+Table "tables/tenRows.csv" sliced, written 4 slices, 10 rows, total size 101 B, manifest created.

--- a/test/processor/mode-slices-empty-table-manifest/expected-stdout
+++ b/test/processor/mode-slices-empty-table-manifest/expected-stdout
@@ -1,3 +1,3 @@
 Configured number of slices is 4, min 1 B per slice.
 Slicing table "tables/empty.csv".
-Table "tables/empty.csv" sliced. Written 1 parts, 0 rows, total size 0 B.
+Table "tables/empty.csv" sliced, written 1 slices, 0 rows, total size 0 B.

--- a/test/processor/mode-slices-empty-table/expected-stdout
+++ b/test/processor/mode-slices-empty-table/expected-stdout
@@ -1,3 +1,3 @@
 Configured number of slices is 4, min 1 B per slice.
 Slicing table "tables/empty.csv".
-Table "tables/empty.csv" sliced. Written 1 parts, 0 rows, total size 0 B. Manifest created.
+Table "tables/empty.csv" sliced, written 1 slices, 0 rows, total size 0 B, manifest created.

--- a/test/processor/mode-slices-min-size/expected-stdout
+++ b/test/processor/mode-slices-min-size/expected-stdout
@@ -1,3 +1,3 @@
 Configured number of slices is 4, min 1.5 MiB per slice.
 Slicing table "tables/table.csv".
-Table "tables/table.csv" sliced. Written 1 parts, 2 rows, total size 20 B. Manifest created.
+Table "tables/table.csv" sliced, written 1 slices, 2 rows, total size 20 B, manifest created.

--- a/test/processor/mode-slices-one-row/expected-stdout
+++ b/test/processor/mode-slices-one-row/expected-stdout
@@ -1,3 +1,3 @@
 Configured number of slices is 4, min 1 B per slice.
 Slicing table "tables/oneRow.csv".
-Table "tables/oneRow.csv" sliced. Written 1 parts, 1 rows, total size 10 B. Manifest created.
+Table "tables/oneRow.csv" sliced, written 1 slices, 1 rows, total size 10 B, manifest created.

--- a/test/processor/mode-slices-two-rows/expected-stdout
+++ b/test/processor/mode-slices-two-rows/expected-stdout
@@ -1,3 +1,3 @@
 Configured number of slices is 4, min 1 B per slice.
 Slicing table "tables/twoRows.csv".
-Table "tables/twoRows.csv" sliced. Written 2 parts, 2 rows, total size 20 B. Manifest created.
+Table "tables/twoRows.csv" sliced, written 2 slices, 2 rows, total size 20 B, manifest created.

--- a/test/processor/mode-slices/expected-stdout
+++ b/test/processor/mode-slices/expected-stdout
@@ -1,3 +1,3 @@
 Configured number of slices is 4, min 1 B per slice.
 Slicing table "tables/tenRows.csv".
-Table "tables/tenRows.csv" sliced. Written 4 parts, 10 rows, total size 101 B. Manifest created.
+Table "tables/tenRows.csv" sliced, written 4 slices, 10 rows, total size 101 B, manifest created.


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-294

Changes:
- Panics replaced by error return value.
- Fix error message format according Go standards: lowercase, without `.`.

--------------------

Pred 2 rokmi, ked tento processor vznikol sme skopirovali ako sa vyvijaju komponenty v PHP:
- Namiesto `User/AppException` sme pouzili `panic`.

Teraz ked na to pozeram po 2 rokoch:
- Tak mi strasne vadi, ze nevidim, kde v kode moze nastat chyba.
- Blbo sa to testuje, neocakavany `panic` ti zastavi vsetky testy, ocakavany `panic` sa zase blbo assertuje (cez callback).
- Kym to bol nejaky jednorazovy workaround pre C..., tak to asi az tak nevadi, ale teraz to ma byt uz pevna sucast platformy.