### PR TITLE
Unify logger

### DIFF
--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"runtime/debug"
 	"runtime/pprof"
@@ -11,34 +10,33 @@ import (
 	"github.com/keboola/processor-split-table/internal/pkg/config"
 	"github.com/keboola/processor-split-table/internal/pkg/finder"
 	"github.com/keboola/processor-split-table/internal/pkg/kbc"
+	"github.com/keboola/processor-split-table/internal/pkg/log"
 	"github.com/keboola/processor-split-table/internal/pkg/processor"
 )
 
 func main() {
+	logger := log.NewLogger()
+
 	// Handle panic with correct exit code
 	defer func() {
 		if err := recover(); err != nil {
-			exitWithError(err)
+			exitWithError(logger, err)
 		}
 	}()
 
-	// Remove timestamp prefix from logs
-	log.SetFlags(0)
-
 	// Cpu profiling can be enabled by flag
 	if started, err := startCPUProfileIfFlagSet(); err != nil {
-		exitWithError(err)
+		exitWithError(logger, err)
 	} else if started {
 		defer pprof.StopCPUProfile()
 	}
 
-	if err := run(); err != nil {
-		exitWithError(err)
+	if err := run(logger); err != nil {
+		exitWithError(logger, err)
 	}
 }
 
-func run() error {
-	logger := log.New(os.Stdout, "", 0)
+func run(logger log.Logger) error {
 	inputDir := kbc.GetInputDir()
 	outputDir := kbc.GetOutputDir()
 
@@ -62,7 +60,7 @@ func run() error {
 	return nil
 }
 
-func exitWithError(err any) {
+func exitWithError(logger log.Logger, err any) {
 	// Get message
 	var msg string
 	if e, ok := err.(error); ok {
@@ -78,11 +76,11 @@ func exitWithError(err any) {
 	}
 
 	// Print message
-	log.Println("Error:", msg)
+	logger.Error("Error: ", msg)
 
 	// Log stack trace for Application Error
 	if exitCode > 1 {
-		log.Println("Trace: \n" + string(debug.Stack()))
+		logger.Error("Trace: \n" + string(debug.Stack()))
 	}
 
 	os.Exit(exitCode)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/klauspost/pgzip v1.2.6
 	github.com/otiai10/copy v1.14.0
 	github.com/stretchr/testify v1.8.4
+	go.uber.org/zap v1.26.0
 )
 
 require (
@@ -19,6 +20,7 @@ require (
 	github.com/klauspost/compress v1.12.2 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
+go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
+go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=
 golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"reflect"
 	"strings"
@@ -54,7 +53,7 @@ func (m *Mode) UnmarshalText(b []byte) error {
 	return nil
 }
 
-func LoadConfig(configPath string) (*Config, error) {
+func LoadConfig(configPath string) (cfg *Config, err error) {
 	// Open config
 	f, err := os.OpenFile(configPath, os.O_RDONLY, 0o640)
 	if err != nil {
@@ -65,8 +64,8 @@ func LoadConfig(configPath string) (*Config, error) {
 		}
 	}
 	defer func() {
-		if err := f.Close(); err != nil {
-			log.Println(fmt.Errorf(`cannot close file "%s": %w`, configPath, err))
+		if closeErr := f.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf(`cannot close file "%s": %w`, configPath, err)
 		}
 	}()
 

--- a/internal/pkg/csv/slice.go
+++ b/internal/pkg/csv/slice.go
@@ -2,19 +2,19 @@ package csv
 
 import (
 	"fmt"
-	"log"
 
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 
 	"github.com/keboola/processor-split-table/internal/pkg/config"
 	manifestPkg "github.com/keboola/processor-split-table/internal/pkg/csv/manifest"
 	"github.com/keboola/processor-split-table/internal/pkg/csv/rowsreader"
 	"github.com/keboola/processor-split-table/internal/pkg/csv/slicedwriter"
+	"github.com/keboola/processor-split-table/internal/pkg/log"
 	"github.com/keboola/processor-split-table/internal/pkg/utils"
 )
 
-func SliceCsv(logger *log.Logger, conf *config.Config, relativePath string, inPath string, inManifestPath string, outPath string, outManifestPath string) (err error) {
-	logger.Printf("Slicing table \"%s\".\n", relativePath)
+func SliceCsv(logger log.Logger, conf *config.Config, relativePath string, inPath string, inManifestPath string, outPath string, outManifestPath string) (err error) {
+	logger.Infof("Slicing table \"%s\".", relativePath)
 
 	// Create target dir
 	if err := utils.Mkdir(outPath); err != nil {
@@ -87,7 +87,7 @@ func SliceCsv(logger *log.Logger, conf *config.Config, relativePath string, inPa
 	return logResult(logger, writer, relativePath, outPath, createManifest, addColumnsToManifest)
 }
 
-func logResult(logger *log.Logger, w *slicedwriter.SlicedWriter, relativePath string, absPath string, createManifest bool, addColumnsToManifest bool) error {
+func logResult(logger log.Logger, w *slicedwriter.SlicedWriter, relativePath string, absPath string, createManifest bool, addColumnsToManifest bool) error {
 	msg := fmt.Sprintf(
 		"Table \"%s\" sliced, written %d slices, %s rows, total size %s",
 		relativePath,
@@ -113,6 +113,6 @@ func logResult(logger *log.Logger, w *slicedwriter.SlicedWriter, relativePath st
 		msg += "."
 	}
 
-	logger.Println(msg)
+	logger.Info(msg)
 	return nil
 }

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -1,0 +1,33 @@
+package log
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type Logger interface {
+	Debug(args ...any)
+	Info(args ...any)
+	Warn(args ...any)
+	Error(args ...any)
+	Debugf(template string, args ...any)
+	Infof(template string, args ...any)
+	Warnf(template string, args ...any)
+	Errorf(template string, args ...any)
+}
+
+// NewLogger creates a logger that logs messages by default to STDOUT and Warn/Error levels to STDERR.
+func NewLogger() Logger {
+	toInfoLevel := zap.LevelEnablerFunc(func(l zapcore.Level) bool {
+		return l == zapcore.DebugLevel || l == zapcore.InfoLevel
+	})
+	fromWarnLevel := zapcore.WarnLevel
+
+	encoder := zapcore.NewConsoleEncoder(zapcore.EncoderConfig{MessageKey: "msg"})
+	return zap.New(zapcore.NewTee(
+		zapcore.NewCore(encoder, zapcore.AddSync(os.Stdout), toInfoLevel),
+		zapcore.NewCore(encoder, zapcore.AddSync(os.Stderr), fromWarnLevel),
+	)).Sugar()
+}

--- a/internal/pkg/processor/processor.go
+++ b/internal/pkg/processor/processor.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/dustin/go-humanize"
 
@@ -10,19 +9,20 @@ import (
 	"github.com/keboola/processor-split-table/internal/pkg/csv"
 	"github.com/keboola/processor-split-table/internal/pkg/finder"
 	"github.com/keboola/processor-split-table/internal/pkg/kbc"
+	"github.com/keboola/processor-split-table/internal/pkg/log"
 	"github.com/keboola/processor-split-table/internal/pkg/utils"
 )
 
 // Processor processes files found by Finder.
 type Processor struct {
-	logger    *log.Logger
+	logger    log.Logger
 	config    *config.Config
 	inputDir  string
 	outputDir string
 	files     []*finder.FileNode
 }
 
-func NewProcessor(logger *log.Logger, conf *config.Config, inputDir string, outputDir string, files []*finder.FileNode) *Processor {
+func NewProcessor(logger log.Logger, conf *config.Config, inputDir string, outputDir string, files []*finder.FileNode) *Processor {
 	return &Processor{logger: logger, config: conf, inputDir: inputDir, outputDir: outputDir, files: files}
 }
 
@@ -38,11 +38,11 @@ func (p *Processor) Run() error {
 	// Log settings
 	switch p.config.Parameters.Mode {
 	case config.ModeBytes:
-		p.logger.Printf("Configured max %s per slice.", humanize.IBytes(p.config.Parameters.BytesPerSlice))
+		p.logger.Infof("Configured max %s per slice.", humanize.IBytes(p.config.Parameters.BytesPerSlice))
 	case config.ModeRows:
-		p.logger.Printf("Configured max %s rows per slice.", humanize.Comma(int64(p.config.Parameters.RowsPerSlice)))
+		p.logger.Infof("Configured max %s rows per slice.", humanize.Comma(int64(p.config.Parameters.RowsPerSlice)))
 	case config.ModeSlices:
-		p.logger.Printf(
+		p.logger.Infof(
 			"Configured number of slices is %d, min %s per slice.",
 			p.config.Parameters.NumberOfSlices,
 			humanize.IBytes(p.config.Parameters.MinBytesPerSlice),
@@ -52,7 +52,7 @@ func (p *Processor) Run() error {
 	}
 
 	if p.config.Parameters.Gzip {
-		p.logger.Printf("Gzip enabled, compression level = %d.", p.config.Parameters.GzipLevel)
+		p.logger.Infof("Gzip enabled, compression level = %d.", p.config.Parameters.GzipLevel)
 	}
 
 	// Process all found files
@@ -74,7 +74,7 @@ func (p *Processor) Run() error {
 			}
 		case finder.CsvTableSliced:
 			// Already sliced tables are copied from in -> out
-			p.logger.Printf("Copying already sliced table \"%s\".\n", file.RelativePath)
+			p.logger.Infof("Copying already sliced table \"%s\".", file.RelativePath)
 			if err := utils.CopyRecursive(inPath, outPath); err != nil {
 				return err
 			}
@@ -88,7 +88,7 @@ func (p *Processor) Run() error {
 
 		case finder.File:
 			// Files are copied from in -> out
-			p.logger.Printf("Copying \"%s\".\n", file.RelativePath)
+			p.logger.Infof("Copying \"%s\".", file.RelativePath)
 			if err := utils.CopyRecursive(inPath, outPath); err != nil {
 				return err
 			}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-294

Changes:
- Unified logging, used `uber zap` logger.

--------------------

- Standardny Go logger loguje vsetko na jedno miesto (napr. stdout) a je dost basic.
- Nahradil som to za `zap` logger, pouzivany aj v KAC repe.
- Procesor ako komponenta musi logovat na `stdout` a chyby/warnings na `stderr`.
- Pred touto zmenou to nebolo jednotne.