### PR TITLE
Split processor/config code to slicer/config

### DIFF
--- a/internal/pkg/processor/config/config.go
+++ b/internal/pkg/processor/config/config.go
@@ -13,45 +13,11 @@ import (
 	"github.com/go-playground/validator/v10"
 
 	"github.com/keboola/processor-split-table/internal/pkg/kbc"
+	slicerConfig "github.com/keboola/processor-split-table/internal/pkg/slicer/config"
 )
-
-const (
-	ModeBytes Mode = iota + 1
-	ModeRows
-	ModeSlices
-)
-
-type Mode uint
 
 type Config struct {
-	Parameters Parameters `json:"parameters" validate:"required"`
-}
-
-type Parameters struct {
-	Mode             Mode   `json:"mode" validate:"required"`
-	BytesPerSlice    uint64 `json:"bytesPerSlice" validate:"min=1"`
-	RowsPerSlice     uint64 `json:"rowsPerSlice" validate:"min=1"`
-	NumberOfSlices   uint32 `json:"numberOfSlices" validate:"min=1"`
-	MinBytesPerSlice uint64 `json:"minBytesPerSlice" validate:"min=1"` // if Mode = ModeSlices
-	Gzip             bool   `json:"gzip"`
-	GzipLevel        int    `json:"gzipLevel" validate:"min=1,max=9"`
-}
-
-func (m *Mode) UnmarshalText(b []byte) error {
-	// Convert "mode" string value to numeric constant
-	str := string(b)
-	switch str {
-	case "bytes":
-		*m = ModeBytes
-	case "rows":
-		*m = ModeRows
-	case "slices":
-		*m = ModeSlices
-	default:
-		return fmt.Errorf(`unexpected value "%s" for "mode", use "rows", "bytes" or "slices"`, str)
-	}
-
-	return nil
+	Parameters slicerConfig.Config `json:"parameters" validate:"required"`
 }
 
 func LoadConfig(configPath string) (cfg *Config, err error) {
@@ -77,17 +43,7 @@ func LoadConfig(configPath string) (cfg *Config, err error) {
 	}
 
 	// Default values
-	conf := &Config{
-		Parameters: Parameters{
-			Mode:             ModeBytes,
-			BytesPerSlice:    524_288_000, // 500 MiB
-			RowsPerSlice:     1_000_000,
-			NumberOfSlices:   60,
-			MinBytesPerSlice: 4194304, // 4 MiB
-			Gzip:             true,
-			GzipLevel:        2, // 1 - BestSpeed, 9 - BestCompression
-		},
-	}
+	conf := &Config{Parameters: slicerConfig.DefaultConfig()}
 
 	// Parse JSON
 	err = json.Unmarshal(content, conf)

--- a/internal/pkg/processor/config/config_test.go
+++ b/internal/pkg/processor/config/config_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	slicerConfig "github.com/keboola/processor-split-table/internal/pkg/slicer/config"
 )
 
 type testData struct {
@@ -82,8 +84,8 @@ func getTestData() []testData {
 			input:   "{}",
 			error:   "",
 			expected: &Config{
-				Parameters: Parameters{
-					Mode:             ModeBytes,
+				Parameters: slicerConfig.Config{
+					Mode:             slicerConfig.ModeBytes,
 					BytesPerSlice:    524_288_000,
 					RowsPerSlice:     1_000_000,
 					NumberOfSlices:   60,
@@ -98,8 +100,8 @@ func getTestData() []testData {
 			input:   "{\"parameters\": {}}",
 			error:   "",
 			expected: &Config{
-				Parameters: Parameters{
-					Mode:             ModeBytes,
+				Parameters: slicerConfig.Config{
+					Mode:             slicerConfig.ModeBytes,
 					BytesPerSlice:    524_288_000,
 					RowsPerSlice:     1_000_000,
 					NumberOfSlices:   60,
@@ -114,8 +116,8 @@ func getTestData() []testData {
 			input:   "{\"parameters\": {\"gzip\": true, \"gzipLevel\": 5}}",
 			error:   "",
 			expected: &Config{
-				Parameters: Parameters{
-					Mode:             ModeBytes,
+				Parameters: slicerConfig.Config{
+					Mode:             slicerConfig.ModeBytes,
 					BytesPerSlice:    524_288_000,
 					RowsPerSlice:     1_000_000,
 					NumberOfSlices:   60,
@@ -130,8 +132,8 @@ func getTestData() []testData {
 			input:   "{\"parameters\": {\"gzip\": false}}",
 			error:   "",
 			expected: &Config{
-				Parameters: Parameters{
-					Mode:             ModeBytes,
+				Parameters: slicerConfig.Config{
+					Mode:             slicerConfig.ModeBytes,
 					BytesPerSlice:    524_288_000,
 					RowsPerSlice:     1_000_000,
 					NumberOfSlices:   60,
@@ -146,8 +148,8 @@ func getTestData() []testData {
 			input:   "{\"parameters\": {\"mode\": \"rows\", \"rowsPerSlice\": 123}}",
 			error:   "",
 			expected: &Config{
-				Parameters: Parameters{
-					Mode:             ModeRows,
+				Parameters: slicerConfig.Config{
+					Mode:             slicerConfig.ModeRows,
 					BytesPerSlice:    524_288_000,
 					RowsPerSlice:     123,
 					NumberOfSlices:   60,
@@ -162,8 +164,8 @@ func getTestData() []testData {
 			input:   "{\"parameters\": {\"mode\": \"bytes\", \"bytesPerSlice\": 123}}",
 			error:   "",
 			expected: &Config{
-				Parameters: Parameters{
-					Mode:             ModeBytes,
+				Parameters: slicerConfig.Config{
+					Mode:             slicerConfig.ModeBytes,
 					BytesPerSlice:    123,
 					RowsPerSlice:     1_000_000,
 					NumberOfSlices:   60,
@@ -178,8 +180,8 @@ func getTestData() []testData {
 			input:   "{\"parameters\": {\"mode\": \"slices\", \"numberOfSlices\": 123}}",
 			error:   "",
 			expected: &Config{
-				Parameters: Parameters{
-					Mode:             ModeSlices,
+				Parameters: slicerConfig.Config{
+					Mode:             slicerConfig.ModeSlices,
 					BytesPerSlice:    524_288_000,
 					RowsPerSlice:     1_000_000,
 					NumberOfSlices:   123,
@@ -194,8 +196,8 @@ func getTestData() []testData {
 			input:   "{\"parameters\": {\"mode\": \"slices\", \"minBytesPerSlice\": 123}}",
 			error:   "",
 			expected: &Config{
-				Parameters: Parameters{
-					Mode:             ModeSlices,
+				Parameters: slicerConfig.Config{
+					Mode:             slicerConfig.ModeSlices,
 					BytesPerSlice:    524_288_000,
 					RowsPerSlice:     1_000_000,
 					NumberOfSlices:   60,

--- a/internal/pkg/processor/processor.go
+++ b/internal/pkg/processor/processor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keboola/processor-split-table/internal/pkg/processor/config"
 	"github.com/keboola/processor-split-table/internal/pkg/processor/finder"
 	"github.com/keboola/processor-split-table/internal/pkg/slicer"
+	slicerConfig "github.com/keboola/processor-split-table/internal/pkg/slicer/config"
 	"github.com/keboola/processor-split-table/internal/pkg/utils"
 )
 
@@ -40,11 +41,11 @@ func Run(logger log.Logger) error {
 
 	// Log settings
 	switch cfg.Parameters.Mode {
-	case config.ModeBytes:
+	case slicerConfig.ModeBytes:
 		logger.Infof("Configured max %s per slice.", humanize.IBytes(cfg.Parameters.BytesPerSlice))
-	case config.ModeRows:
+	case slicerConfig.ModeRows:
 		logger.Infof("Configured max %s rows per slice.", humanize.Comma(int64(cfg.Parameters.RowsPerSlice)))
-	case config.ModeSlices:
+	case slicerConfig.ModeSlices:
 		logger.Infof(
 			"Configured number of slices is %d, min %s per slice.",
 			cfg.Parameters.NumberOfSlices,
@@ -68,7 +69,7 @@ func Run(logger log.Logger) error {
 		switch file.FileType {
 		case finder.CsvTableSingle:
 			// Single file CSV tables -> split
-			if err := slicer.SliceCsv(logger, cfg, file.RelativePath, inPath, inManifestPath, outPath, outManifestPath); err != nil {
+			if err := slicer.SliceCsv(logger, cfg.Parameters, file.RelativePath, inPath, inManifestPath, outPath, outManifestPath); err != nil {
 				return err
 			}
 		case finder.Directory:

--- a/internal/pkg/slicer/config/config.go
+++ b/internal/pkg/slicer/config/config.go
@@ -1,0 +1,50 @@
+package config
+
+import "fmt"
+
+const (
+	ModeBytes Mode = iota + 1
+	ModeRows
+	ModeSlices
+)
+
+type Mode uint
+
+type Config struct {
+	Mode             Mode   `json:"mode" validate:"required"`
+	BytesPerSlice    uint64 `json:"bytesPerSlice" validate:"min=1"`
+	RowsPerSlice     uint64 `json:"rowsPerSlice" validate:"min=1"`
+	NumberOfSlices   uint32 `json:"numberOfSlices" validate:"min=1"`
+	MinBytesPerSlice uint64 `json:"minBytesPerSlice" validate:"min=1"` // if Mode = ModeSlices
+	Gzip             bool   `json:"gzip"`
+	GzipLevel        int    `json:"gzipLevel" validate:"min=1,max=9"`
+}
+
+func DefaultConfig() Config {
+	return Config{
+		Mode:             ModeBytes,
+		BytesPerSlice:    524_288_000, // 500 MiB
+		RowsPerSlice:     1_000_000,
+		NumberOfSlices:   60,
+		MinBytesPerSlice: 4194304, // 4 MiB
+		Gzip:             true,
+		GzipLevel:        2, // 1 - BestSpeed, 9 - BestCompression
+	}
+}
+
+func (m *Mode) UnmarshalText(b []byte) error {
+	// Convert "mode" string value to numeric constant
+	str := string(b)
+	switch str {
+	case "bytes":
+		*m = ModeBytes
+	case "rows":
+		*m = ModeRows
+	case "slices":
+		*m = ModeSlices
+	default:
+		return fmt.Errorf(`unexpected value "%s" for "mode", use "rows", "bytes" or "slices"`, str)
+	}
+
+	return nil
+}

--- a/internal/pkg/slicer/slicedwriter/slice.go
+++ b/internal/pkg/slicer/slicedwriter/slice.go
@@ -20,9 +20,7 @@ const (
 
 // slice writes to the one slice.
 type slice struct {
-	mode        config.Mode
-	maxBytes    uint64
-	maxRows     uint64
+	config      config.Config
 	path        string
 	file        *os.File
 	writer      io.Writer
@@ -31,7 +29,7 @@ type slice struct {
 	bytesFromGc uint64 // bytes from last garbage collector run
 }
 
-func newSlice(mode config.Mode, maxBytes uint64, maxRows uint64, gzipEnabled bool, gzipLevel int, filePath string) (*slice, error) {
+func newSlice(cfg config.Config, filePath string) (*slice, error) {
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, kbc.NewFilePermissions)
 	if err != nil {
 		return nil, err
@@ -39,8 +37,8 @@ func newSlice(mode config.Mode, maxBytes uint64, maxRows uint64, gzipEnabled boo
 
 	// Use gzip compression?
 	var writer io.Writer
-	if gzipEnabled {
-		writer, err = gzip.NewWriterLevel(file, gzipLevel)
+	if cfg.Gzip {
+		writer, err = gzip.NewWriterLevel(file, cfg.GzipLevel)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create gzip writer: %w", err)
 		}
@@ -48,17 +46,7 @@ func newSlice(mode config.Mode, maxBytes uint64, maxRows uint64, gzipEnabled boo
 		writer = bufio.NewWriterSize(file, OutBufferSize)
 	}
 
-	return &slice{
-		mode,
-		maxBytes,
-		maxRows,
-		filePath,
-		file,
-		writer,
-		0,
-		0,
-		0,
-	}, nil
+	return &slice{config: cfg, path: filePath, file: file, writer: writer}, nil
 }
 
 func (s *slice) Write(row []byte, rowLength uint64) error {
@@ -117,12 +105,12 @@ func (s *slice) IsSpaceForNextRow(rowLength uint64) bool {
 		return true
 	}
 
-	switch s.mode {
+	switch s.config.Mode {
 	case config.ModeBytes:
-		return s.bytes+rowLength <= s.maxBytes
+		return s.bytes+rowLength <= s.config.BytesPerSlice
 	case config.ModeRows:
-		return s.rows < s.maxRows
+		return s.rows < s.config.RowsPerSlice
 	default:
-		panic(fmt.Errorf("unexpected sliced writer mode \"%v\"", s.mode))
+		panic(fmt.Errorf("unexpected sliced writer mode \"%v\"", s.config.Mode))
 	}
 }

--- a/internal/pkg/slicer/slicedwriter/slice.go
+++ b/internal/pkg/slicer/slicedwriter/slice.go
@@ -10,7 +10,7 @@ import (
 	gzip "github.com/klauspost/pgzip"
 
 	"github.com/keboola/processor-split-table/internal/pkg/kbc"
-	"github.com/keboola/processor-split-table/internal/pkg/processor/config"
+	"github.com/keboola/processor-split-table/internal/pkg/slicer/config"
 )
 
 const (

--- a/internal/pkg/slicer/slicedwriter/writer.go
+++ b/internal/pkg/slicer/slicedwriter/writer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/keboola/processor-split-table/internal/pkg/processor/config"
+	"github.com/keboola/processor-split-table/internal/pkg/slicer/config"
 )
 
 // SlicedWriter writes CSV to a sliced table defined by dirPath.
@@ -24,11 +24,11 @@ type SlicedWriter struct {
 	allBytes      uint64
 }
 
-func NewSlicedWriterFromConf(conf *config.Config, inFileSize uint64, outPath string) (*SlicedWriter, error) {
-	mode := conf.Parameters.Mode
-	bytesPerSlice := conf.Parameters.BytesPerSlice
-	rowsPerSlice := conf.Parameters.RowsPerSlice
-	maxSlices := conf.Parameters.NumberOfSlices
+func NewSlicedWriterFromConf(cfg config.Config, inFileSize uint64, outPath string) (*SlicedWriter, error) {
+	mode := cfg.Mode
+	bytesPerSlice := cfg.BytesPerSlice
+	rowsPerSlice := cfg.RowsPerSlice
+	maxSlices := cfg.NumberOfSlices
 
 	// Fixed number of slices -> calculate bytesPerSlice
 	if mode == config.ModeSlices {
@@ -37,14 +37,14 @@ func NewSlicedWriterFromConf(conf *config.Config, inFileSize uint64, outPath str
 		bytesPerSlice = uint64(math.Ceil(fileSize / float64(maxSlices)))
 
 		// Too small slices (a few kilobytes) can slow down upload -> check min size
-		if bytesPerSlice < conf.Parameters.MinBytesPerSlice {
-			bytesPerSlice = conf.Parameters.MinBytesPerSlice
+		if bytesPerSlice < cfg.MinBytesPerSlice {
+			bytesPerSlice = cfg.MinBytesPerSlice
 		}
 	} else {
 		maxSlices = 0 // disabled
 	}
 
-	return NewSlicedWriter(mode, bytesPerSlice, rowsPerSlice, maxSlices, conf.Parameters.Gzip, conf.Parameters.GzipLevel, outPath)
+	return NewSlicedWriter(mode, bytesPerSlice, rowsPerSlice, maxSlices, cfg.Gzip, cfg.GzipLevel, outPath)
 }
 
 func NewSlicedWriter(mode config.Mode, bytesPerSlice uint64, rowsPerSlice uint64, maxSlices uint32, gzipEnabled bool, gzipLevel int, dirPath string) (*SlicedWriter, error) {

--- a/internal/pkg/slicer/slicedwriter/writer_test.go
+++ b/internal/pkg/slicer/slicedwriter/writer_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/keboola/processor-split-table/internal/pkg/processor/config"
+	"github.com/keboola/processor-split-table/internal/pkg/slicer/config"
 	"github.com/keboola/processor-split-table/internal/pkg/utils"
 )
 
 type testData struct {
-	conf         *config.Config
+	config       config.Config
 	rows         []string
 	expectedErr  error
 	expectedPath string
@@ -26,15 +26,13 @@ func TestNewSlicedWriter(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Config
-	conf := &config.Config{
-		Parameters: config.Parameters{
-			Mode:          config.ModeBytes,
-			BytesPerSlice: 123,
-		},
+	cfg := config.Config{
+		Mode:          config.ModeBytes,
+		BytesPerSlice: 123,
 	}
 
 	// Create writer
-	w, err := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	w, err := NewSlicedWriterFromConf(cfg, 1000, tempDir)
 	require.NoError(t, err)
 
 	// Assert
@@ -56,15 +54,12 @@ func TestCreateNextSlice(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Config
-	conf := &config.Config{
-		Parameters: config.Parameters{
-			Mode:          config.ModeBytes,
-			BytesPerSlice: 123,
-		},
+	cfg := config.Config{
+		Mode:          config.ModeBytes,
+		BytesPerSlice: 123,
 	}
-
 	// Create writer
-	w, err := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	w, err := NewSlicedWriterFromConf(cfg, 1000, tempDir)
 	require.NoError(t, err)
 
 	require.NoError(t, w.createNextSlice())
@@ -88,15 +83,13 @@ func TestIsSpaceForNextRowBytes(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Config
-	conf := &config.Config{
-		Parameters: config.Parameters{
-			Mode:          config.ModeBytes,
-			BytesPerSlice: 123, // <<<<<<
-		},
+	cfg := config.Config{
+		Mode:          config.ModeBytes,
+		BytesPerSlice: 123, // <<<<<<
 	}
 
 	// Create writer
-	w, err := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	w, err := NewSlicedWriterFromConf(cfg, 1000, tempDir)
 	require.NoError(t, err)
 	w.allRows = 10
 	w.allBytes = 200
@@ -117,15 +110,13 @@ func TestIsSpaceForNextRowRows(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Config
-	conf := &config.Config{
-		Parameters: config.Parameters{
-			Mode:         config.ModeRows,
-			RowsPerSlice: 10,
-		},
+	cfg := config.Config{
+		Mode:         config.ModeRows,
+		RowsPerSlice: 10,
 	}
 
 	// Create writer
-	w, err := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	w, err := NewSlicedWriterFromConf(cfg, 1000, tempDir)
 	require.NoError(t, err)
 	w.allRows = 10
 	w.allBytes = 200
@@ -147,17 +138,15 @@ func TestBytesMode(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Config
-	conf := &config.Config{
-		Parameters: config.Parameters{
-			Mode:           config.ModeBytes,
-			BytesPerSlice:  40,
-			NumberOfSlices: 2, // no effect
-			RowsPerSlice:   2, // no effect
-		},
+	cfg := config.Config{
+		Mode:           config.ModeBytes,
+		BytesPerSlice:  40,
+		NumberOfSlices: 2, // no effect
+		RowsPerSlice:   2, // no effect
 	}
 
 	// Create writer
-	w, err := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	w, err := NewSlicedWriterFromConf(cfg, 1000, tempDir)
 	require.NoError(t, err)
 
 	// 1 slice
@@ -186,17 +175,15 @@ func TestRowsMode(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Config
-	conf := &config.Config{
-		Parameters: config.Parameters{
-			Mode:           config.ModeRows,
-			RowsPerSlice:   3,
-			BytesPerSlice:  5, // no effect
-			NumberOfSlices: 2, // no effect
-		},
+	cfg := config.Config{
+		Mode:           config.ModeRows,
+		RowsPerSlice:   3,
+		BytesPerSlice:  5, // no effect
+		NumberOfSlices: 2, // no effect
 	}
 
 	// Create writer
-	w, err := NewSlicedWriterFromConf(conf, 1000, tempDir)
+	w, err := NewSlicedWriterFromConf(cfg, 1000, tempDir)
 	require.NoError(t, err)
 
 	// 1 slice
@@ -225,18 +212,16 @@ func TestSlicesMode(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Config
-	conf := &config.Config{
-		Parameters: config.Parameters{
-			Mode:             config.ModeSlices,
-			NumberOfSlices:   3,
-			MinBytesPerSlice: 1,
-			BytesPerSlice:    1, // no effect
-			RowsPerSlice:     1, // no effect
-		},
+	cfg := config.Config{
+		Mode:             config.ModeSlices,
+		NumberOfSlices:   3,
+		MinBytesPerSlice: 1,
+		BytesPerSlice:    1, // no effect
+		RowsPerSlice:     1, // no effect
 	}
 
 	// Create writer
-	w, err := NewSlicedWriterFromConf(conf, 7*12, tempDir)
+	w, err := NewSlicedWriterFromConf(cfg, 7*12, tempDir)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(3), w.maxSlices)
 	assert.Equal(t, uint64(28), w.bytesPerSlice) // 7 row * 12 bytes / 3 slices = 28 bytes per slice
@@ -268,7 +253,7 @@ func TestWriteCsv(t *testing.T) {
 
 	for _, testData := range getReadCsvTestData() {
 		tempDir := t.TempDir()
-		w, err := NewSlicedWriterFromConf(testData.conf, 1000, tempDir)
+		w, err := NewSlicedWriterFromConf(testData.config, 1000, tempDir)
 		require.NoError(t, err)
 		for _, row := range testData.rows {
 			assert.NoError(t, w.Write([]byte(row)))
@@ -285,13 +270,13 @@ func getReadCsvTestData() []testData {
 		{
 			expectedPath: "empty",
 			expectedErr:  nil,
-			conf:         &config.Config{Parameters: config.Parameters{Mode: config.ModeBytes, BytesPerSlice: 1000}},
+			config:       config.Config{Mode: config.ModeBytes, BytesPerSlice: 1000},
 			rows:         nil,
 		},
 		{
 			expectedPath: "empty_with_new_line",
 			expectedErr:  nil,
-			conf:         &config.Config{Parameters: config.Parameters{Mode: config.ModeBytes, BytesPerSlice: 1000}},
+			config:       config.Config{Mode: config.ModeBytes, BytesPerSlice: 1000},
 			rows: []string{
 				"\n",
 			},
@@ -299,7 +284,7 @@ func getReadCsvTestData() []testData {
 		{
 			expectedPath: "one_row",
 			expectedErr:  nil,
-			conf:         &config.Config{Parameters: config.Parameters{Mode: config.ModeBytes, BytesPerSlice: 1000}},
+			config:       config.Config{Mode: config.ModeBytes, BytesPerSlice: 1000},
 			rows: []string{
 				"\"abc\",\"def\"\n",
 			},
@@ -307,7 +292,7 @@ func getReadCsvTestData() []testData {
 		{
 			expectedPath: "two_rows",
 			expectedErr:  nil,
-			conf:         &config.Config{Parameters: config.Parameters{Mode: config.ModeBytes, BytesPerSlice: 1000}},
+			config:       config.Config{Mode: config.ModeBytes, BytesPerSlice: 1000},
 			rows: []string{
 				"\"abc\",\"def\"\n",
 				"\"123\",\"456\"\n",
@@ -316,7 +301,7 @@ func getReadCsvTestData() []testData {
 		{
 			expectedPath: "escaping",
 			expectedErr:  nil,
-			conf:         &config.Config{Parameters: config.Parameters{Mode: config.ModeBytes, BytesPerSlice: 1000}},
+			config:       config.Config{Mode: config.ModeBytes, BytesPerSlice: 1000},
 			rows: []string{
 				"\"col1\",\"col2\"\n",
 				"\"line with enclosure\",\"second column\"\n",
@@ -331,7 +316,7 @@ func getReadCsvTestData() []testData {
 		{
 			expectedPath: "multiple_parts_bytes_mode",
 			expectedErr:  nil,
-			conf:         &config.Config{Parameters: config.Parameters{Mode: config.ModeBytes, BytesPerSlice: 40}},
+			config:       config.Config{Mode: config.ModeBytes, BytesPerSlice: 40},
 			rows: []string{
 				"\"1bc\",\"def\"\n",
 				"\"2bc\",\"def\"\n",
@@ -345,7 +330,7 @@ func getReadCsvTestData() []testData {
 		{
 			expectedPath: "multiple_parts_rows_mode",
 			expectedErr:  nil,
-			conf:         &config.Config{Parameters: config.Parameters{Mode: config.ModeRows, RowsPerSlice: 3}},
+			config:       config.Config{Mode: config.ModeRows, RowsPerSlice: 3},
 			rows: []string{
 				"\"1bc\",\"def\"\n",
 				"\"2bc\",\"def\"\n",

--- a/internal/pkg/slicer/slicer.go
+++ b/internal/pkg/slicer/slicer.go
@@ -28,7 +28,7 @@ func SliceCsv(logger log.Logger, conf config.Config, relativePath string, inPath
 	}
 
 	// Create writer
-	writer, err := slicedwriter.NewSlicedWriterFromConf(conf, fileSize, outPath)
+	writer, err := slicedwriter.New(conf, fileSize, outPath)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/slicer/slicer.go
+++ b/internal/pkg/slicer/slicer.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/keboola/processor-split-table/internal/pkg/log"
 	manifestPkg "github.com/keboola/processor-split-table/internal/pkg/manifest"
-	"github.com/keboola/processor-split-table/internal/pkg/processor/config"
+	"github.com/keboola/processor-split-table/internal/pkg/slicer/config"
 	"github.com/keboola/processor-split-table/internal/pkg/slicer/rowsreader"
 	"github.com/keboola/processor-split-table/internal/pkg/slicer/slicedwriter"
 	"github.com/keboola/processor-split-table/internal/pkg/utils"
 )
 
-func SliceCsv(logger log.Logger, conf *config.Config, relativePath string, inPath string, inManifestPath string, outPath string, outManifestPath string) (err error) {
+func SliceCsv(logger log.Logger, conf config.Config, relativePath string, inPath string, inManifestPath string, outPath string, outManifestPath string) (err error) {
 	logger.Infof("Slicing table \"%s\".", relativePath)
 
 	// Create target dir


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PSGO-294

Changes:
- Created `slicer/config` pkg from `processor/config`, so the structure can be used by the CLI.
- Simplified code.
- No change in tests.