### PR TITLE
Fix logged output bytes size

### DIFF
--- a/internal/pkg/slicer/slicer.go
+++ b/internal/pkg/slicer/slicer.go
@@ -98,11 +98,6 @@ func SliceTable(logger log.Logger, table Table) (err error) {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if closeErr := writer.Close(); closeErr != nil && err == nil {
-			err = closeErr
-		}
-	}()
 
 	// If manifest without defined columns -> store first row/header to manifest "columns" key
 	addColumnsToManifest := !manifest.HasColumns()
@@ -126,8 +121,8 @@ func SliceTable(logger log.Logger, table Table) (err error) {
 		return fmt.Errorf("error when reading CSV \"%s\": %w", table.InPath, err)
 	}
 
-	// Write manifest
-	if err := manifest.WriteTo(table.OutManifestPath); err != nil {
+	// Close the writer
+	if err = writer.Close(); err != nil {
 		return err
 	}
 
@@ -139,6 +134,11 @@ func SliceTable(logger log.Logger, table Table) (err error) {
 		} else {
 			return err
 		}
+	}
+
+	// Write manifest
+	if err := manifest.WriteTo(table.OutManifestPath); err != nil {
+		return err
 	}
 
 	// Log statistics

--- a/test/cli/dump-config/expected-stdout
+++ b/test/cli/dump-config/expected-stdout
@@ -24,4 +24,4 @@ Configuration: {
   "cpuProfile": ""
 }
 Slicing table "mytable".
-Table "mytable" sliced: in/out: 1 / 1 slices, 22B / 10B bytes, 3 rows, manifest created.
+Table "mytable" sliced: in/out: 1 / 1 slices, 22B / 42B bytes, 3 rows, manifest created.


### PR DESCRIPTION
Slack: https://keboolaglobal.slack.com/archives/C055WKPHYSD/p1701160471672459

Changes:
- Slices writer is closed before calculation of the output slices size, so the right size is then logged.